### PR TITLE
Feat/analyses enhancement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Production-ready Dockerfile for Next.js application
-FROM node:18-alpine AS base
+FROM node:20-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Copy package files
@@ -12,6 +13,7 @@ RUN npm install --production=false --legacy-peer-deps
 
 # Build the source code
 FROM base AS builder
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/src/app/components/InspectorSidebar.tsx
+++ b/src/app/components/InspectorSidebar.tsx
@@ -65,6 +65,10 @@ const InspectorSidebar = ({
       if (items.length > 0) {
         setItem(items[0])
         setIsOpen(true)
+      } else {
+        // Item was deleted — clear inspector
+        setItem(null)
+        setFocusedItem(undefined)
       }
     } else {
       setItem(null)

--- a/src/app/components/InspectorSidebar.tsx
+++ b/src/app/components/InspectorSidebar.tsx
@@ -176,6 +176,11 @@ const InspectorSidebar = ({
                       flattenedEntries.push([key, value]),
                     )
 
+                  // Inject folder name for molecules
+                  if ((item as ExtendedFolder).dtype === 'molecule') {
+                    flattenedEntries.push(['name', item.name])
+                  }
+
                   // Add extended_metadata fields if they exist
                   if (
                     metadata.extended_metadata &&

--- a/src/app/components/Workspace.tsx
+++ b/src/app/components/Workspace.tsx
@@ -25,6 +25,8 @@ import { ExportFilesText } from './workspace/ExportFilesText'
 import { Toolbar } from './workspace/Toolbar'
 import { UploadFilesText } from './workspace/UploadFilesText'
 import { UploadedFiles } from './workspace/UploadedFiles'
+import RenamePopup from './tree-view/RenamePopup'
+import DeletePopup from './tree-view/DeletePopup'
 
 type Database = {
   assignedFiles: ExtendedFile[]
@@ -105,6 +107,18 @@ const Workspace = ({
   const [contextTarget, setContextTarget] = useState<
     ExtendedFile | ExtendedFolder
   >()
+
+  const [renamingItem, setRenamingItem] = useState<{
+    item: ExtendedFile | ExtendedFolder
+    x: number
+    y: number
+  } | null>(null)
+
+  const [deletingItem, setDeletingItem] = useState<{
+    item: ExtendedFile | ExtendedFolder
+    x: number
+    y: number
+  } | null>(null)
 
   if (!db)
     return (
@@ -223,19 +237,22 @@ const Workspace = ({
   const assignmentTreeContextMenuClose = () =>
     setAssignmentTreeContextMenu(initialContextMenu)
 
-  const handleShowContextMenu = async (
-    fullPath: string,
-    x: number,
-    y: number,
-  ) => {
-    const retrievedFile = await filesDB.files.get({ fullPath })
-    const retrievedFolder = await filesDB.folders.get({ fullPath })
-    const retrieved = retrievedFile || retrievedFolder
-    if (!retrieved) return
+  const fetchItem = async (fullPath: string) => {
+    const file = await filesDB.files.get({ fullPath })
+    const folder = await filesDB.folders.get({ fullPath })
+    return file || folder
+  }
 
-    setContextTarget(retrieved)
-    setAssignmentTreeContextMenu({ show: true, x, y })
-    fileTreeContextMenuClose()
+  const handleRenameClick = async (fullPath: string, x: number, y: number) => {
+    const item = await fetchItem(fullPath)
+    if (!item) return
+    setRenamingItem({ item, x, y })
+  }
+
+  const handleDeleteClick = async (fullPath: string, x: number, y: number) => {
+    const item = await fetchItem(fullPath)
+    if (!item) return
+    setDeletingItem({ item, x, y })
   }
 
   return (
@@ -310,11 +327,10 @@ const Workspace = ({
                       {children}
                     </div>
                   )}
-                  renderItem={createRenderItem(
-                    tree,
-                    setExpandedItems,
-                    handleShowContextMenu,
-                  )}
+                  renderItem={createRenderItem(tree, setExpandedItems, {
+                    onRenameClick: handleRenameClick,
+                    onDeleteClick: handleDeleteClick,
+                  })}
                   rootItem={assignmentTreeRoot}
                   treeId="assignmentTree"
                   treeLabel="Assignment Tree"
@@ -338,6 +354,24 @@ const Workspace = ({
               tree={tree}
               x={assignmentTreeContextMenu.x}
               y={assignmentTreeContextMenu.y}
+            />
+          )}
+          {renamingItem && (
+            <RenamePopup
+              item={renamingItem.item}
+              tree={tree}
+              x={renamingItem.x}
+              y={renamingItem.y}
+              onClose={() => setRenamingItem(null)}
+            />
+          )}
+          {deletingItem && (
+            <DeletePopup
+              item={deletingItem.item}
+              tree={tree}
+              x={deletingItem.x}
+              y={deletingItem.y}
+              onClose={() => setDeletingItem(null)}
             />
           )}
         </div>

--- a/src/app/components/Workspace.tsx
+++ b/src/app/components/Workspace.tsx
@@ -223,6 +223,21 @@ const Workspace = ({
   const assignmentTreeContextMenuClose = () =>
     setAssignmentTreeContextMenu(initialContextMenu)
 
+  const handleShowContextMenu = async (
+    fullPath: string,
+    x: number,
+    y: number,
+  ) => {
+    const retrievedFile = await filesDB.files.get({ fullPath })
+    const retrievedFolder = await filesDB.folders.get({ fullPath })
+    const retrieved = retrievedFile || retrievedFolder
+    if (!retrieved) return
+
+    setContextTarget(retrieved)
+    setAssignmentTreeContextMenu({ show: true, x, y })
+    fileTreeContextMenuClose()
+  }
+
   return (
     <Fragment>
       <Toolbar
@@ -295,7 +310,11 @@ const Workspace = ({
                       {children}
                     </div>
                   )}
-                  renderItem={createRenderItem(tree, setExpandedItems)}
+                  renderItem={createRenderItem(
+                    tree,
+                    setExpandedItems,
+                    handleShowContextMenu,
+                  )}
                   rootItem={assignmentTreeRoot}
                   treeId="assignmentTree"
                   treeLabel="Assignment Tree"

--- a/src/app/components/Workspace.tsx
+++ b/src/app/components/Workspace.tsx
@@ -271,7 +271,7 @@ const Workspace = ({
                         {children}
                       </div>
                     )}
-                    renderItem={createRenderItem(tree)}
+                    renderItem={createRenderItem(tree, setExpandedItems)}
                     rootItem={inputTreeRoot}
                     treeId="inputTree"
                     treeLabel="Input Tree"
@@ -295,7 +295,7 @@ const Workspace = ({
                       {children}
                     </div>
                   )}
-                  renderItem={createRenderItem(tree)}
+                  renderItem={createRenderItem(tree, setExpandedItems)}
                   rootItem={assignmentTreeRoot}
                   treeId="assignmentTree"
                   treeLabel="Assignment Tree"

--- a/src/app/components/context-menu/AssignmentTreeContextMenu.tsx
+++ b/src/app/components/context-menu/AssignmentTreeContextMenu.tsx
@@ -39,6 +39,7 @@ const ClickOnAnalysesContextMenu = ({
       targetItem={targetItem}
       tree={tree}
       hideDeleteOption={true}
+      hideRenameOption={true}
     />
   </>
 )

--- a/src/app/components/context-menu/DefaultContextMenu.tsx
+++ b/src/app/components/context-menu/DefaultContextMenu.tsx
@@ -37,5 +37,4 @@ const DefaultContextMenu = ({
   </>
 )
 
-
 export default DefaultContextMenu

--- a/src/app/components/context-menu/DefaultContextMenu.tsx
+++ b/src/app/components/context-menu/DefaultContextMenu.tsx
@@ -10,18 +10,22 @@ const DefaultContextMenu = ({
   targetItem,
   tree,
   hideDeleteOption = false,
+  hideRenameOption = false,
 }: {
   closeContextMenu: () => void
   targetItem: ExtendedFile | ExtendedFolder
   tree: Record<string, FileNode>
   hideDeleteOption?: boolean
+  hideRenameOption?: boolean
 }) => (
   <>
-    <RenameContextMenuItem
-      close={closeContextMenu}
-      item={targetItem}
-      tree={tree}
-    />
+    {!hideRenameOption && (
+      <RenameContextMenuItem
+        close={closeContextMenu}
+        item={targetItem}
+        tree={tree}
+      />
+    )}
     <ContextMenuDivider />
     {!hideDeleteOption && (
       <DeleteContextMenuItem
@@ -32,5 +36,6 @@ const DefaultContextMenu = ({
     )}
   </>
 )
+
 
 export default DefaultContextMenu

--- a/src/app/components/context-menu/context-menu-items/DeleteContextMenuItem.tsx
+++ b/src/app/components/context-menu/context-menu-items/DeleteContextMenuItem.tsx
@@ -3,9 +3,7 @@ import { FileNode } from '@/helper/types'
 import { useOnClickOutside } from '@/hooks/useOnClickOutside'
 import { FC, useRef, useState } from 'react'
 import { FaDeleteLeft } from 'react-icons/fa6'
-
-import deleteFile from '../deleteFile'
-import deleteFolder from '../deleteFolder'
+import DeleteConfirm from '../../shared/DeleteConfirm'
 
 interface DeleteProps {
   className?: string
@@ -21,24 +19,9 @@ const DeleteContextMenuItem: FC<DeleteProps> = ({
   tree,
 }) => {
   const popupRef = useRef<HTMLDivElement>(null)
-
   const [showConfirmation, setShowConfirmation] = useState(false)
 
   useOnClickOutside(popupRef, () => setShowConfirmation(false))
-
-  const handleDelete = (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!item.isFolder) deleteFile(item as ExtendedFile)
-    else deleteFolder(item as ExtendedFolder, tree)
-
-    close()
-  }
-
-  const handleCancel = (e: { stopPropagation: () => void }) => {
-    e.stopPropagation()
-    setShowConfirmation(false)
-  }
 
   return (
     <li
@@ -54,29 +37,12 @@ const DeleteContextMenuItem: FC<DeleteProps> = ({
           className="absolute left-full top-[-5px] z-10 ml-2 origin-left-center animate-emerge-from-lamp rounded-lg border border-gray-300 bg-white p-1 shadow-lg"
           ref={popupRef}
         >
-          <div className="flex flex-col space-y-1">
-            <span className="w-auto min-w-[150px] max-w-[300px] truncate whitespace-nowrap rounded-sm p-1 text-center shadow">
-              Delete{' '}
-              <span className="underline" title={item.name}>
-                {item.name}
-              </span>
-              ?
-            </span>
-            <div className="flex justify-end space-x-2">
-              <button
-                className="flex-1 rounded bg-blue-500 px-3 py-1 text-white hover:bg-blue-700"
-                onClick={handleDelete}
-              >
-                Confirm
-              </button>
-              <button
-                className="flex-1 rounded bg-red-500 px-3 py-1 text-white hover:bg-red-700"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
+          <DeleteConfirm
+            item={item}
+            tree={tree}
+            onDone={close}
+            onCancel={() => setShowConfirmation(false)}
+          />
         </div>
       )}
     </li>

--- a/src/app/components/context-menu/context-menu-items/RenameContextMenuItem.tsx
+++ b/src/app/components/context-menu/context-menu-items/RenameContextMenuItem.tsx
@@ -3,9 +3,7 @@ import { FileNode } from '@/helper/types'
 import { useOnClickOutside } from '@/hooks/useOnClickOutside'
 import { FC, useRef, useState } from 'react'
 import { FaEdit } from 'react-icons/fa'
-
-import renameFile from '../renameFile'
-import renameFolder from '../renameFolder'
+import RenameForm from '../../shared/RenameForm'
 
 interface RenameProps {
   className?: string
@@ -21,44 +19,9 @@ const RenameContextMenuItem: FC<RenameProps> = ({
   tree,
 }) => {
   const popupRef = useRef(null)
-
-  const [newName, setNewName] = useState(item.name)
   const [showInput, setShowInput] = useState(false)
-  const [newFullPathAvailable, setNewFullPathAvailable] = useState(false)
 
   useOnClickOutside(popupRef, () => showInput && setShowInput(false))
-
-  const validateNewName = (userInput: string) => {
-    setNewName(userInput)
-    const parentPath =
-      item.fullPath.split('/').slice(0, -1).join('/') || 'inputTreeRoot'
-
-    const validInput = userInput.trim().length > 0 && !userInput.includes('/')
-
-    const newPath =
-      parentPath === 'inputTreeRoot' ? userInput : parentPath + '/' + userInput
-
-    const nameAvailable = !tree[parentPath].children.includes(newPath)
-
-    setNewFullPathAvailable(validInput && nameAvailable)
-  }
-
-  const handleCancel = (e: { stopPropagation: () => void }) => {
-    e.stopPropagation()
-    setShowInput(false)
-    setNewName(item.name)
-  }
-
-  const handleRename = (e: React.FormEvent) => {
-    e.preventDefault()
-
-    tree[item.fullPath].data = newName
-
-    if (!item.isFolder) renameFile(item as ExtendedFile, newName)
-    else renameFolder(item as ExtendedFolder, tree, newName)
-
-    close()
-  }
 
   return (
     <li
@@ -74,33 +37,12 @@ const RenameContextMenuItem: FC<RenameProps> = ({
           className="absolute left-full top-[-5px] z-10 ml-2 origin-left-center animate-emerge-from-lamp rounded-lg border border-gray-300 bg-white p-1 shadow-lg"
           ref={popupRef}
         >
-          <div className="flex flex-col space-y-1">
-            <input
-              className="rounded px-3 py-1 shadow focus:outline-none"
-              onChange={(e) => validateNewName(e.target.value)}
-              placeholder="Enter new folder name"
-              value={newName}
-            />
-            <div className="flex justify-end space-x-2">
-              <button
-                className={`${
-                  !newFullPathAvailable
-                    ? 'bg-gray-200 hover:bg-gray-200'
-                    : 'hover:bg-blue-700'
-                } flex-1 rounded bg-blue-500 px-3 py-1 text-white`}
-                disabled={!newFullPathAvailable}
-                onClick={handleRename}
-              >
-                Rename
-              </button>
-              <button
-                className="flex-1 rounded bg-red-500 px-3 py-1 text-white hover:bg-red-700"
-                onClick={handleCancel}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
+          <RenameForm
+            item={item}
+            tree={tree}
+            onDone={close}
+            onCancel={() => setShowInput(false)}
+          />
         </div>
       )}
     </li>

--- a/src/app/components/hooks/useMetadataHandlers.ts
+++ b/src/app/components/hooks/useMetadataHandlers.ts
@@ -95,7 +95,10 @@ export const useMetadataHandlers = ({
 
           // Only update tree/state for the currently selected item
           if (fullPath === item.fullPath) {
-            if (key === 'name') {
+            if (
+              key === 'name' &&
+              (item as ExtendedFolder).dtype !== 'molecule'
+            ) {
               renameFolder(item as ExtendedFolder, tree, newValue as string)
             }
 

--- a/src/app/components/input-components/OntologyTreeSelect.tsx
+++ b/src/app/components/input-components/OntologyTreeSelect.tsx
@@ -8,11 +8,7 @@ interface OntologyItem {
   is_enabled?: boolean
   selectable?: boolean
   id?: number
-  children: OntologyItem[]
-}
-
-interface OntologyData {
-  ols_terms: OntologyItem[]
+  children?: OntologyItem[]
 }
 
 interface TreeSelectFieldProps {
@@ -24,67 +20,98 @@ interface TreeSelectFieldProps {
   name?: string
 }
 
-// Cache for ontology data
-const ontologyCache = new Map<string, any[]>()
+const RECENTLY_SELECTED_MAX = 10
+const RECENT_PREFIX = '__recent__'
+const ONTOLOGY_LABELS: Record<string, string> = {
+  Kind: 'Type (Chemicals Method Ontology - CHMO)',
+  Rxno: 'Type (Name Reaction Ontology - RXNO)',
+}
 
-// Transform ontology data (simplified)
-const transformOntologyData = (data: OntologyItem[]): any[] => {
+// Raw JSON cache — fetched once per type, never invalidated
+const rawDataCache = new Map<string, OntologyItem[]>()
+
+const getRecentlySelected = (ontologyType: string): OntologyItem[] => {
+  try {
+    const stored = localStorage.getItem(`ontology_recent_${ontologyType}`)
+    return stored ? JSON.parse(stored) : []
+  } catch {
+    return []
+  }
+}
+
+const addRecentlySelected = (ontologyType: string, item: OntologyItem) => {
+  const current = getRecentlySelected(ontologyType)
+  if (current.find((i) => i.value === item.value)) return
+  const updated = [item, ...current].slice(0, RECENTLY_SELECTED_MAX)
+  try {
+    localStorage.setItem(`ontology_recent_${ontologyType}`, JSON.stringify(updated))
+  } catch {}
+}
+
+const transformOntologyData = (data: OntologyItem[], ontologyType: string): any[] => {
   const usedKeys = new Set<string>()
 
-  const transform = (items: OntologyItem[]): any[] => {
-    return items
-      .filter((item) => item.selectable !== false)
+  const transform = (items: OntologyItem[]): any[] =>
+    items
       .map((item) => {
-        // Create unique key for duplicates
+        if (item.selectable === false) {
+          if (item.title !== '-- Recently selected --') return null
+          const recent = getRecentlySelected(ontologyType)
+          if (recent.length === 0) return null
+          return {
+            title: item.title,
+            value: item.value,
+            key: '__recently_selected__',
+            children: recent.map((r) => ({
+              title: r.title,
+              value: `${RECENT_PREFIX}${r.value}`,
+              key: `${RECENT_PREFIX}${r.value}`,
+            })),
+          }
+        }
+
         let uniqueKey = item.value
         let counter = 1
-        while (usedKeys.has(uniqueKey)) {
-          uniqueKey = `${item.value}__${counter}`
-          counter++
-        }
+        while (usedKeys.has(uniqueKey)) uniqueKey = `${item.value}__${counter++}`
         usedKeys.add(uniqueKey)
 
         return {
           title: item.title,
           value: item.value,
           key: uniqueKey,
-          children:
-            item.children?.length > 0 ? transform(item.children) : undefined,
+          children: item.children?.length ? transform(item.children) : undefined,
           disabled: item.is_enabled === false,
         }
       })
-  }
+      .filter(Boolean)
 
   return transform(data)
 }
 
-// Load ontology data
-const loadOntologyData = async (
-  ontologyType: 'reaction' | 'analysis',
-): Promise<any[]> => {
-  if (ontologyCache.has(ontologyType)) {
-    return ontologyCache.get(ontologyType)!
+const loadOntologyData = async (ontologyType: 'reaction' | 'analysis'): Promise<any[]> => {
+  if (!rawDataCache.has(ontologyType)) {
+    const fileName = ontologyType === 'reaction' ? 'rxno.json' : 'chmo.json'
+    const response = await fetch(`/data/ontologies/${fileName}`)
+    if (!response.ok) throw new Error(`Failed to load ${fileName}`)
+    const { ols_terms } = await response.json()
+    rawDataCache.set(ontologyType, ols_terms)
   }
-
-  const fileName = ontologyType === 'reaction' ? 'rxno.json' : 'chmo.json'
-  const response = await fetch(`/data/ontologies/${fileName}`)
-
-  if (!response.ok) {
-    throw new Error(`Failed to load ${fileName}`)
-  }
-
-  const data: OntologyData = await response.json()
-  const transformedData = transformOntologyData(data.ols_terms)
-  ontologyCache.set(ontologyType, transformedData)
-  return transformedData
+  return transformOntologyData(rawDataCache.get(ontologyType)!, ontologyType)
 }
 
-// Simple filter function
-const filterTreeNode = (input: string, child: any): boolean => {
-  const searchText =
-    child.title?.toLowerCase() || child.value?.toLowerCase() || ''
-  return searchText.includes(input?.toLowerCase() || '')
+const findInTree = (nodes: any[], value: string): any => {
+  for (const node of nodes) {
+    if (node.value === value) return node
+    if (node.children) {
+      const found = findInTree(node.children, value)
+      if (found) return found
+    }
+  }
+  return null
 }
+
+const filterTreeNode = (input: string, child: any): boolean =>
+  (child.title?.toLowerCase() ?? '').includes(input?.toLowerCase() ?? '')
 
 const OntologyTreeSelect: React.FC<TreeSelectFieldProps> = ({
   value,
@@ -100,38 +127,29 @@ const OntologyTreeSelect: React.FC<TreeSelectFieldProps> = ({
 
   useEffect(() => {
     let mounted = true
-
-    const loadData = async () => {
-      setLoading(true)
-      setError(null)
-
-      try {
-        const data = await loadOntologyData(ontologyType)
-        if (mounted) {
-          setTreeData(data)
-        }
-      } catch (err) {
-        if (mounted) {
-          setError(
-            err instanceof Error ? err.message : 'Failed to load ontology data',
-          )
-        }
-      } finally {
-        if (mounted) {
-          setLoading(false)
-        }
-      }
-    }
-
-    loadData()
-    return () => {
-      mounted = false
-    }
+    setLoading(true)
+    setError(null)
+    loadOntologyData(ontologyType)
+      .then((data) => { if (mounted) setTreeData(data) })
+      .catch((err) => { if (mounted) setError(err instanceof Error ? err.message : 'Failed to load ontology data') })
+      .finally(() => { if (mounted) setLoading(false) })
+    return () => { mounted = false }
   }, [ontologyType])
 
   const handleChange = (selectedValue: string) => {
-    if (onChange && !readonly) {
-      onChange(selectedValue || '')
+    if (readonly) return
+    const cleanValue = selectedValue?.startsWith(RECENT_PREFIX)
+      ? selectedValue.slice(RECENT_PREFIX.length)
+      : selectedValue
+    if (!cleanValue || cleanValue === 'recently selected') return
+
+    onChange?.(cleanValue)
+
+    const fromRecent = getRecentlySelected(ontologyType).find((r) => r.value === cleanValue)
+    const title = fromRecent?.title ?? findInTree(treeData, cleanValue)?.title
+    if (title) {
+      addRecentlySelected(ontologyType, { title, value: cleanValue })
+      setTreeData(transformOntologyData(rawDataCache.get(ontologyType)!, ontologyType))
     }
   }
 
@@ -152,17 +170,11 @@ const OntologyTreeSelect: React.FC<TreeSelectFieldProps> = ({
     )
   }
 
-  const onthologyLabel = name
-    ? formatLabel(name) === 'Kind'
-      ? 'Type (Chemicals Method Ontology - CHMO)'
-      : formatLabel(name) === 'Rxno'
-      ? 'Type (Name Reaction Ontology - RXNO)'
-      : undefined
-    : undefined
+  const ontologyLabel = name ? ONTOLOGY_LABELS[formatLabel(name)] : undefined
 
   return (
     <label className="flex flex-col text-sm">
-      {onthologyLabel && <p className="font-bold mb-2">{onthologyLabel}</p>}
+      {ontologyLabel && <p className="font-bold mb-2">{ontologyLabel}</p>}
       <TreeSelect
         style={{ width: '100%' }}
         value={value || undefined}

--- a/src/app/components/input-components/OntologyTreeSelect.tsx
+++ b/src/app/components/input-components/OntologyTreeSelect.tsx
@@ -44,11 +44,17 @@ const addRecentlySelected = (ontologyType: string, item: OntologyItem) => {
   if (current.find((i) => i.value === item.value)) return
   const updated = [item, ...current].slice(0, RECENTLY_SELECTED_MAX)
   try {
-    localStorage.setItem(`ontology_recent_${ontologyType}`, JSON.stringify(updated))
+    localStorage.setItem(
+      `ontology_recent_${ontologyType}`,
+      JSON.stringify(updated),
+    )
   } catch {}
 }
 
-const transformOntologyData = (data: OntologyItem[], ontologyType: string): any[] => {
+const transformOntologyData = (
+  data: OntologyItem[],
+  ontologyType: string,
+): any[] => {
   const usedKeys = new Set<string>()
 
   const transform = (items: OntologyItem[]): any[] =>
@@ -72,14 +78,17 @@ const transformOntologyData = (data: OntologyItem[], ontologyType: string): any[
 
         let uniqueKey = item.value
         let counter = 1
-        while (usedKeys.has(uniqueKey)) uniqueKey = `${item.value}__${counter++}`
+        while (usedKeys.has(uniqueKey))
+          uniqueKey = `${item.value}__${counter++}`
         usedKeys.add(uniqueKey)
 
         return {
           title: item.title,
           value: item.value,
           key: uniqueKey,
-          children: item.children?.length ? transform(item.children) : undefined,
+          children: item.children?.length
+            ? transform(item.children)
+            : undefined,
           disabled: item.is_enabled === false,
         }
       })
@@ -88,7 +97,9 @@ const transformOntologyData = (data: OntologyItem[], ontologyType: string): any[
   return transform(data)
 }
 
-const loadOntologyData = async (ontologyType: 'reaction' | 'analysis'): Promise<any[]> => {
+const loadOntologyData = async (
+  ontologyType: 'reaction' | 'analysis',
+): Promise<any[]> => {
   if (!rawDataCache.has(ontologyType)) {
     const fileName = ontologyType === 'reaction' ? 'rxno.json' : 'chmo.json'
     const response = await fetch(`/data/ontologies/${fileName}`)
@@ -130,10 +141,21 @@ const OntologyTreeSelect: React.FC<TreeSelectFieldProps> = ({
     setLoading(true)
     setError(null)
     loadOntologyData(ontologyType)
-      .then((data) => { if (mounted) setTreeData(data) })
-      .catch((err) => { if (mounted) setError(err instanceof Error ? err.message : 'Failed to load ontology data') })
-      .finally(() => { if (mounted) setLoading(false) })
-    return () => { mounted = false }
+      .then((data) => {
+        if (mounted) setTreeData(data)
+      })
+      .catch((err) => {
+        if (mounted)
+          setError(
+            err instanceof Error ? err.message : 'Failed to load ontology data',
+          )
+      })
+      .finally(() => {
+        if (mounted) setLoading(false)
+      })
+    return () => {
+      mounted = false
+    }
   }, [ontologyType])
 
   const handleChange = (selectedValue: string) => {
@@ -145,11 +167,15 @@ const OntologyTreeSelect: React.FC<TreeSelectFieldProps> = ({
 
     onChange?.(cleanValue)
 
-    const fromRecent = getRecentlySelected(ontologyType).find((r) => r.value === cleanValue)
+    const fromRecent = getRecentlySelected(ontologyType).find(
+      (r) => r.value === cleanValue,
+    )
     const title = fromRecent?.title ?? findInTree(treeData, cleanValue)?.title
     if (title) {
       addRecentlySelected(ontologyType, { title, value: cleanValue })
-      setTreeData(transformOntologyData(rawDataCache.get(ontologyType)!, ontologyType))
+      setTreeData(
+        transformOntologyData(rawDataCache.get(ontologyType)!, ontologyType),
+      )
     }
   }
 

--- a/src/app/components/mappers/inputComponentMapper.tsx
+++ b/src/app/components/mappers/inputComponentMapper.tsx
@@ -82,7 +82,18 @@ export function determineInputComponent<T extends ZodRawShape>({
   if (!schema) return null
 
   const [type] = identifyType(schema, key)
-  const readonly = key === 'decoupled' ? !isMolValid : isReadonly(key)
+  const isMolecule = (currentItem as ExtendedFolder)?.dtype === 'molecule'
+  const readonly =
+    key === 'decoupled'
+      ? !isMolValid
+      : key === 'name' && isMolecule
+        ? false
+        : isReadonly(key)
+
+  // Molecule name is not in the schema — render as editable string field directly
+  if (key === 'name' && isMolecule) {
+    return renderStringField(key, value, readonly, handleInputChange, currentItem)
+  }
 
   if (isQuantityUnit(key)) {
     return null

--- a/src/app/components/mappers/inputComponentMapper.tsx
+++ b/src/app/components/mappers/inputComponentMapper.tsx
@@ -87,12 +87,18 @@ export function determineInputComponent<T extends ZodRawShape>({
     key === 'decoupled'
       ? !isMolValid
       : key === 'name' && isMolecule
-        ? false
-        : isReadonly(key)
+      ? false
+      : isReadonly(key)
 
   // Molecule name is not in the schema — render as editable string field directly
   if (key === 'name' && isMolecule) {
-    return renderStringField(key, value, readonly, handleInputChange, currentItem)
+    return renderStringField(
+      key,
+      value,
+      readonly,
+      handleInputChange,
+      currentItem,
+    )
   }
 
   if (isQuantityUnit(key)) {

--- a/src/app/components/shared/DeleteConfirm.tsx
+++ b/src/app/components/shared/DeleteConfirm.tsx
@@ -1,0 +1,63 @@
+import { ExtendedFile, ExtendedFolder } from '@/database/db'
+import { FileNode } from '@/helper/types'
+import { FC } from 'react'
+
+import deleteFile from '../context-menu/deleteFile'
+import deleteFolder from '../context-menu/deleteFolder'
+
+interface DeleteConfirmProps {
+  item: ExtendedFile | ExtendedFolder
+  tree: Record<string, FileNode>
+  onDone: () => void
+  onCancel: () => void
+}
+
+const DeleteConfirm: FC<DeleteConfirmProps> = ({
+  item,
+  tree,
+  onDone,
+  onCancel,
+}) => {
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!item.isFolder) deleteFile(item as ExtendedFile)
+    else deleteFolder(item as ExtendedFolder, tree)
+    onDone()
+  }
+
+  const handleCancel = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onCancel()
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm">
+        Delete{' '}
+        <span className="font-medium underline" title={item.name}>
+          {item.name}
+        </span>
+        ?
+      </p>
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          className="rounded px-3 py-1 text-sm text-gray-600 hover:bg-gray-100"
+          onClick={handleCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="rounded bg-red-500 px-3 py-1 text-sm text-white hover:bg-red-600"
+          onClick={handleDelete}
+          autoFocus
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default DeleteConfirm

--- a/src/app/components/shared/RenameForm.tsx
+++ b/src/app/components/shared/RenameForm.tsx
@@ -1,0 +1,70 @@
+import { ExtendedFile, ExtendedFolder } from '@/database/db'
+import { FileNode } from '@/helper/types'
+import { useRename } from '@/hooks/useRename'
+import { FC, useEffect, useRef } from 'react'
+
+interface RenameFormProps {
+  item: ExtendedFile | ExtendedFolder
+  tree: Record<string, FileNode>
+  onDone: () => void
+  onCancel: () => void
+}
+
+const RenameForm: FC<RenameFormProps> = ({ item, tree, onDone, onCancel }) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { newName, isValid, validate, reset, executeRename } = useRename(
+    item,
+    tree,
+    onDone,
+  )
+
+  useEffect(() => {
+    inputRef.current?.select()
+  }, [])
+
+  const handleCancel = (e?: React.MouseEvent | React.KeyboardEvent) => {
+    e?.stopPropagation()
+    reset()
+    onCancel()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') handleCancel()
+  }
+
+  return (
+    <form onSubmit={executeRename} className="flex flex-col gap-2">
+      <input
+        ref={inputRef}
+        className="rounded border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none"
+        onChange={(e) => validate(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Enter new name"
+        value={newName}
+        autoFocus
+      />
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          className="rounded px-3 py-1 text-sm text-gray-600 hover:bg-gray-100"
+          onClick={handleCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className={`rounded px-3 py-1 text-sm text-white ${
+            isValid
+              ? 'bg-blue-500 hover:bg-blue-600'
+              : 'cursor-not-allowed bg-gray-300'
+          }`}
+          disabled={!isValid}
+        >
+          Rename
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default RenameForm

--- a/src/app/components/structure-btns/folderUtils.ts
+++ b/src/app/components/structure-btns/folderUtils.ts
@@ -81,6 +81,7 @@ export const createFolder = async (
   metadata: Metadata = { container_type: 'folder' },
   dtype: Datatype = 'folder',
   reactionSchemeType: ReactionSchemeType = 'none',
+  position?: number,
 ): Promise<ExtendedFolder> => {
   const folder: ExtendedFolder = {
     dtype,
@@ -89,6 +90,7 @@ export const createFolder = async (
     metadata,
     name,
     parentUid,
+    position,
     reactionSchemeType,
     treeId: assignmentTree ? 'assignmentTreeRoot' : 'inputTreeRoot',
     uid: v4(),

--- a/src/app/components/structure-btns/templates.ts
+++ b/src/app/components/structure-btns/templates.ts
@@ -17,7 +17,7 @@ import {
   createSubFolders,
   getUniqueFolderName,
 } from './folderUtils'
-import { ReactionSchemeType } from '@/database/db'
+import { ReactionSchemeType, filesDB } from '@/database/db'
 
 const getMetadata = (
   parent_id: string,
@@ -310,6 +310,14 @@ export const createAnalysis = async (
     fullPath,
   )
 
+  // Determine position = number of existing analysis siblings
+  const existingAnalyses = await filesDB.folders
+    .where('parentUid')
+    .equals(parentUid)
+    .and((f) => f.dtype === 'analysis')
+    .toArray()
+  const nextPosition = existingAnalyses.length
+
   const analysisFolder = await createFolder(
     `${fullPath}/${uniqueFolderName}`,
     uniqueFolderName,
@@ -317,6 +325,8 @@ export const createAnalysis = async (
     parentUid,
     getMetadata(parentUid, uniqueFolderName, 'analysis', '') as any,
     'analysis',
+    'none',
+    nextPosition,
   )
 
   const datasetFolders = await createSubFolders(

--- a/src/app/components/tree-view/DeletePopup.tsx
+++ b/src/app/components/tree-view/DeletePopup.tsx
@@ -1,0 +1,38 @@
+import { ExtendedFile, ExtendedFolder } from '@/database/db'
+import { FileNode } from '@/helper/types'
+import { useOnClickOutside } from '@/hooks/useOnClickOutside'
+import { usePopupPosition } from '@/hooks/usePopupPosition'
+import { FC, useRef } from 'react'
+import DeleteConfirm from '../shared/DeleteConfirm'
+
+interface DeletePopupProps {
+  item: ExtendedFile | ExtendedFolder
+  tree: Record<string, FileNode>
+  x: number
+  y: number
+  onClose: () => void
+}
+
+const DeletePopup: FC<DeletePopupProps> = ({ item, tree, x, y, onClose }) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const pos = usePopupPosition(ref, x, y)
+
+  useOnClickOutside(ref, onClose)
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 rounded-lg border border-gray-300 bg-white p-3 shadow-lg"
+      style={{ left: pos.left, top: pos.top }}
+    >
+      <DeleteConfirm
+        item={item}
+        tree={tree}
+        onDone={onClose}
+        onCancel={onClose}
+      />
+    </div>
+  )
+}
+
+export default DeletePopup

--- a/src/app/components/tree-view/RenamePopup.tsx
+++ b/src/app/components/tree-view/RenamePopup.tsx
@@ -1,0 +1,33 @@
+import { ExtendedFile, ExtendedFolder } from '@/database/db'
+import { FileNode } from '@/helper/types'
+import { useOnClickOutside } from '@/hooks/useOnClickOutside'
+import { usePopupPosition } from '@/hooks/usePopupPosition'
+import { FC, useRef } from 'react'
+import RenameForm from '../shared/RenameForm'
+
+interface RenamePopupProps {
+  item: ExtendedFile | ExtendedFolder
+  tree: Record<string, FileNode>
+  x: number
+  y: number
+  onClose: () => void
+}
+
+const RenamePopup: FC<RenamePopupProps> = ({ item, tree, x, y, onClose }) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const pos = usePopupPosition(ref, x, y)
+
+  useOnClickOutside(ref, onClose)
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 rounded-lg border border-gray-300 bg-white p-2 shadow-lg"
+      style={{ left: pos.left, top: pos.top }}
+    >
+      <RenameForm item={item} tree={tree} onDone={onClose} onCancel={onClose} />
+    </div>
+  )
+}
+
+export default RenamePopup

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -295,7 +295,7 @@ const createRenderItem = (
             </span>
             {showRenameDelete && (
               <button
-                className="px-0.5 py-0.5 ml-1 rounded text-amber-500 hover:text-amber-600 hover:bg-amber-50 transition-all duration-150 shrink-0"
+                className="px-1 py-1 ml-1 bg-amber-500 text-white hover:bg-amber-600 rounded duration-150 transition-colors shrink-0"
                 onClick={handleRenameClick}
                 onMouseDown={(e) => e.preventDefault()}
                 onFocus={(e) => e.stopPropagation()}
@@ -317,7 +317,7 @@ const createRenderItem = (
                 title="Add sample to reaction"
                 type="button"
               >
-                <FaPlus className="w-3 h-3" />
+                <FaPlus className="w-2.5 h-2.5" />
               </button>
             )}
             {isAnalysesFolder && (
@@ -334,7 +334,7 @@ const createRenderItem = (
             )}
             {showRenameDelete && (
               <button
-                className="px-1 py-1 rounded text-red-500 hover:text-red-600 hover:bg-red-50 transition-all duration-150"
+                className="px-1 py-1 bg-red-500 text-white hover:bg-red-600 rounded duration-150 transition-colors"
                 onClick={handleDeleteClick}
                 onMouseDown={(e) => e.preventDefault()}
                 onFocus={(e) => e.stopPropagation()}

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -272,6 +272,8 @@ const createRenderItem = (
             <button
               className="px-1 py-1 mt-1 mb-1 bg-kit-primary-full text-white hover:bg-kit-primary-full/90 rounded duration-150 transition-colors text-xs font-medium"
               onClick={handleAddSampleToReaction}
+              onMouseDown={(e) => e.preventDefault()}
+              onFocus={(e) => e.stopPropagation()}
               title="Add sample to reaction"
               type="button"
             >
@@ -281,7 +283,9 @@ const createRenderItem = (
           {isAnalysesFolder && (
             <button
               className="px-1 py-1 mt-1 mb-1 bg-emerald-600 text-white hover:bg-emerald-700 rounded duration-150 transition-colors text-xs font-medium"
+              onMouseDown={(e) => e.preventDefault()}
               onClick={handleAddAnalysisToAnalyses}
+              onFocus={(e) => e.stopPropagation()}
               title="Add analysis"
               type="button"
             >

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -4,7 +4,7 @@ import {
   TreeItemIndex,
   TreeItemRenderContext,
 } from 'react-complex-tree'
-import { FaEllipsisVertical, FaPlus } from 'react-icons/fa6'
+import { FaPen, FaPlus, FaTrashCan } from 'react-icons/fa6'
 
 import { FileNode } from '@/helper/types'
 import { ICONS } from './fileIcons'
@@ -45,7 +45,10 @@ const Icon = (
 const createRenderItem = (
   tree: Record<string, FileNode>,
   setExpandedItems?: Dispatch<SetStateAction<TreeItemIndex[]>>,
-  onShowContextMenu?: (fullPath: string, x: number, y: number) => void,
+  actions?: {
+    onRenameClick?: (fullPath: string, x: number, y: number) => void
+    onDeleteClick?: (fullPath: string, x: number, y: number) => void
+  },
 ) =>
   function RenderItem({
     children,
@@ -93,13 +96,28 @@ const createRenderItem = (
     const isReactionFolder = fileNode?.isFolder && fileNode.dtype === 'reaction'
     const isSample = fileNode?.isFolder && fileNode.dtype === 'sample'
     const isAnalysesFolder = fileNode?.isFolder && fileNode.dtype === 'analyses'
+    const isStructureFolder =
+      fileNode?.isFolder &&
+      (fileNode.metadata as any)?.container_type === 'structure'
+    const isMoleculeFolder = fileNode?.isFolder && fileNode.dtype === 'molecule'
 
-    // Show menu icon on folders that have context menu actions
-    const showMenuIcon = !shouldHideTitle && !!fileNode && !!onShowContextMenu
+    // Show rename/delete buttons for actionable nodes (not root, not analyses, not structure, not molecule)
+    const showRenameDelete =
+      !shouldHideTitle &&
+      !!fileNode &&
+      !!actions &&
+      !isAnalysesFolder &&
+      !isStructureFolder &&
+      !isMoleculeFolder
 
-    const handleMenuClick = (e: React.MouseEvent) => {
+    const handleRenameClick = (e: React.MouseEvent) => {
       e.stopPropagation()
-      onShowContextMenu?.(String(item.index), e.pageX, e.pageY)
+      actions?.onRenameClick?.(String(item.index), e.pageX, e.pageY)
+    }
+
+    const handleDeleteClick = (e: React.MouseEvent) => {
+      e.stopPropagation()
+      actions?.onDeleteClick?.(String(item.index), e.pageX, e.pageY)
     }
 
     const handleAddAnalysisToAnalyses = async (e: React.MouseEvent) => {
@@ -275,16 +293,16 @@ const createRenderItem = (
                 </>
               )}
             </span>
-            {showMenuIcon && (
+            {showRenameDelete && (
               <button
-                className="px-0.5 py-0.5 ml-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-all duration-150 shrink-0"
-                onClick={handleMenuClick}
+                className="px-0.5 py-0.5 ml-1 rounded text-amber-500 hover:text-amber-600 hover:bg-amber-50 transition-all duration-150 shrink-0"
+                onClick={handleRenameClick}
                 onMouseDown={(e) => e.preventDefault()}
                 onFocus={(e) => e.stopPropagation()}
-                title="Options"
+                title="Rename"
                 type="button"
               >
-                <FaEllipsisVertical className="w-3 h-3" />
+                <FaPen className="w-2.5 h-2.5" />
               </button>
             )}
           </div>
@@ -312,6 +330,18 @@ const createRenderItem = (
                 type="button"
               >
                 <FaPlus className="w-2.5 h-2.5" />
+              </button>
+            )}
+            {showRenameDelete && (
+              <button
+                className="px-1 py-1 rounded text-red-500 hover:text-red-600 hover:bg-red-50 transition-all duration-150"
+                onClick={handleDeleteClick}
+                onMouseDown={(e) => e.preventDefault()}
+                onFocus={(e) => e.stopPropagation()}
+                title="Delete"
+                type="button"
+              >
+                <FaTrashCan className="w-2.5 h-2.5" />
               </button>
             )}
           </div>

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -124,10 +124,10 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
           {...context.itemContainerWithoutChildrenProps}
           {...context.interactiveElementProps}
           data-mykey={item.index}
-          className={`flex items-center justify-between px-2 text-sm
+          className={`flex items-center justify-between px-2 text-sm h-7
           ${
             context.isSelected
-              ? 'my-1 rounded-md bg-kit-primary-mid font-bold'
+              ? 'rounded-md bg-kit-primary-mid font-bold'
               : ''
           }
           ${
@@ -135,7 +135,6 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
           } text-sm text-gray-800 duration-75 hover:text-kit-primary-full`}
           style={{
             marginLeft: `${depth * 25}px`,
-            marginBottom: '2px',
           }}
           type="button"
         >

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -4,7 +4,7 @@ import {
   TreeItemIndex,
   TreeItemRenderContext,
 } from 'react-complex-tree'
-import { FaPlus } from 'react-icons/fa6'
+import { FaEllipsisVertical, FaPlus } from 'react-icons/fa6'
 
 import { FileNode } from '@/helper/types'
 import { ICONS } from './fileIcons'
@@ -45,6 +45,7 @@ const Icon = (
 const createRenderItem = (
   tree: Record<string, FileNode>,
   setExpandedItems?: Dispatch<SetStateAction<TreeItemIndex[]>>,
+  onShowContextMenu?: (fullPath: string, x: number, y: number) => void,
 ) =>
   function RenderItem({
     children,
@@ -92,6 +93,14 @@ const createRenderItem = (
     const isReactionFolder = fileNode?.isFolder && fileNode.dtype === 'reaction'
     const isSample = fileNode?.isFolder && fileNode.dtype === 'sample'
     const isAnalysesFolder = fileNode?.isFolder && fileNode.dtype === 'analyses'
+
+    // Show menu icon on folders that have context menu actions
+    const showMenuIcon = !shouldHideTitle && !!fileNode && !!onShowContextMenu
+
+    const handleMenuClick = (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onShowContextMenu?.(String(item.index), e.pageX, e.pageY)
+    }
 
     const handleAddAnalysisToAnalyses = async (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -266,32 +275,46 @@ const createRenderItem = (
                 </>
               )}
             </span>
+            {showMenuIcon && (
+              <button
+                className="px-0.5 py-0.5 ml-1 rounded text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-all duration-150 shrink-0"
+                onClick={handleMenuClick}
+                onMouseDown={(e) => e.preventDefault()}
+                onFocus={(e) => e.stopPropagation()}
+                title="Options"
+                type="button"
+              >
+                <FaEllipsisVertical className="w-3 h-3" />
+              </button>
+            )}
           </div>
 
-          {isReactionFolder && (
-            <button
-              className="px-1 py-1 mt-1 mb-1 bg-kit-primary-full text-white hover:bg-kit-primary-full/90 rounded duration-150 transition-colors text-xs font-medium"
-              onClick={handleAddSampleToReaction}
-              onMouseDown={(e) => e.preventDefault()}
-              onFocus={(e) => e.stopPropagation()}
-              title="Add sample to reaction"
-              type="button"
-            >
-              <FaPlus className="w-3 h-3" />
-            </button>
-          )}
-          {isAnalysesFolder && (
-            <button
-              className="px-1 py-1 mt-1 mb-1 bg-emerald-600 text-white hover:bg-emerald-700 rounded duration-150 transition-colors text-xs font-medium"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={handleAddAnalysisToAnalyses}
-              onFocus={(e) => e.stopPropagation()}
-              title="Add analysis"
-              type="button"
-            >
-              <FaPlus className="w-2.5 h-2.5" />
-            </button>
-          )}
+          <div className="flex items-center gap-0.5 ml-auto shrink-0">
+            {isReactionFolder && (
+              <button
+                className="px-1 py-1 bg-kit-primary-full text-white hover:bg-kit-primary-full/90 rounded duration-150 transition-colors text-xs font-medium"
+                onClick={handleAddSampleToReaction}
+                onMouseDown={(e) => e.preventDefault()}
+                onFocus={(e) => e.stopPropagation()}
+                title="Add sample to reaction"
+                type="button"
+              >
+                <FaPlus className="w-3 h-3" />
+              </button>
+            )}
+            {isAnalysesFolder && (
+              <button
+                className="px-1 py-1 bg-emerald-600 text-white hover:bg-emerald-700 rounded duration-150 transition-colors text-xs font-medium"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleAddAnalysisToAnalyses}
+                onFocus={(e) => e.stopPropagation()}
+                title="Add analysis"
+                type="button"
+              >
+                <FaPlus className="w-2.5 h-2.5" />
+              </button>
+            )}
+          </div>
         </button>
         {children}
       </li>

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -1,5 +1,9 @@
-import { ReactElement, ReactNode } from 'react'
-import { TreeItem, TreeItemRenderContext } from 'react-complex-tree'
+import { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react'
+import {
+  TreeItem,
+  TreeItemIndex,
+  TreeItemRenderContext,
+} from 'react-complex-tree'
 import { FaPlus } from 'react-icons/fa6'
 
 import { FileNode } from '@/helper/types'
@@ -8,6 +12,7 @@ import { createSample, createAnalysis } from '../structure-btns/templates'
 import { getUniqueFolderName } from '../structure-btns/folderUtils'
 import MoleculeTooltip from './MoleculeTooltip'
 import ReactionTooltip from './ReactionTooltip'
+import { dragNotifications } from '@/utils/dragNotifications'
 
 interface RenderItemParams {
   children: ReactNode
@@ -37,7 +42,10 @@ const Icon = (
     : ICONS.folderPlus
 }
 
-const createRenderItem = (tree: Record<string, FileNode>) =>
+const createRenderItem = (
+  tree: Record<string, FileNode>,
+  setExpandedItems?: Dispatch<SetStateAction<TreeItemIndex[]>>,
+) =>
   function RenderItem({
     children,
     context,
@@ -88,11 +96,25 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
     const handleAddAnalysisToAnalyses = async (e: React.MouseEvent) => {
       e.stopPropagation()
       if (fileNode) {
+        const analysisName = getUniqueFolderName(
+          'analysis',
+          tree,
+          'analysis',
+          false,
+          fileNode.index,
+        )
         await createAnalysis(
           'analysis',
           fileNode.index,
           tree,
           fileNode.uid || '',
+        )
+        setExpandedItems?.((prev) =>
+          prev.includes(fileNode.index) ? prev : [...prev, fileNode.index],
+        )
+        dragNotifications.showSuccess(
+          `"${analysisName}" added to ${parentNode?.data || fileNode.data}`,
+          0,
         )
       }
     }
@@ -115,6 +137,13 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
           fileNode.index,
           fileNode.uid || undefined,
           'product',
+        )
+        setExpandedItems?.((prev) =>
+          prev.includes(fileNode.index) ? prev : [...prev, fileNode.index],
+        )
+        dragNotifications.showSuccess(
+          `"${uniqueSampleName}" added to ${fileNode.data}`,
+          0,
         )
       }
     }

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -88,7 +88,12 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
     const handleAddAnalysisToAnalyses = async (e: React.MouseEvent) => {
       e.stopPropagation()
       if (fileNode) {
-        await createAnalysis('analysis', fileNode.index, tree, fileNode.uid || '')
+        await createAnalysis(
+          'analysis',
+          fileNode.index,
+          tree,
+          fileNode.uid || '',
+        )
       }
     }
 
@@ -125,11 +130,7 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
           {...context.interactiveElementProps}
           data-mykey={item.index}
           className={`flex items-center justify-between px-2 text-sm h-7
-          ${
-            context.isSelected
-              ? 'rounded-md bg-kit-primary-mid font-bold'
-              : ''
-          }
+          ${context.isSelected ? 'rounded-md bg-kit-primary-mid font-bold' : ''}
           ${
             isDraggingOver ? 'rounded-md bg-blue-200' : ''
           } text-sm text-gray-800 duration-75 hover:text-kit-primary-full`}

--- a/src/app/components/tree-view/renderItem.tsx
+++ b/src/app/components/tree-view/renderItem.tsx
@@ -4,7 +4,7 @@ import { FaPlus } from 'react-icons/fa6'
 
 import { FileNode } from '@/helper/types'
 import { ICONS } from './fileIcons'
-import { createSample } from '../structure-btns/templates'
+import { createSample, createAnalysis } from '../structure-btns/templates'
 import { getUniqueFolderName } from '../structure-btns/folderUtils'
 import MoleculeTooltip from './MoleculeTooltip'
 import ReactionTooltip from './ReactionTooltip'
@@ -83,6 +83,14 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
     // Check if this is a reaction folder
     const isReactionFolder = fileNode?.isFolder && fileNode.dtype === 'reaction'
     const isSample = fileNode?.isFolder && fileNode.dtype === 'sample'
+    const isAnalysesFolder = fileNode?.isFolder && fileNode.dtype === 'analyses'
+
+    const handleAddAnalysisToAnalyses = async (e: React.MouseEvent) => {
+      e.stopPropagation()
+      if (fileNode) {
+        await createAnalysis('analysis', fileNode.index, tree, fileNode.uid || '')
+      }
+    }
 
     const handleAddSampleToReaction = async (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -239,6 +247,16 @@ const createRenderItem = (tree: Record<string, FileNode>) =>
               type="button"
             >
               <FaPlus className="w-3 h-3" />
+            </button>
+          )}
+          {isAnalysesFolder && (
+            <button
+              className="px-1 py-1 mt-1 mb-1 bg-emerald-600 text-white hover:bg-emerald-700 rounded duration-150 transition-colors text-xs font-medium"
+              onClick={handleAddAnalysisToAnalyses}
+              title="Add analysis"
+              type="button"
+            >
+              <FaPlus className="w-2.5 h-2.5" />
             </button>
           )}
         </button>

--- a/src/app/components/zip-download/jsonGenerator.ts
+++ b/src/app/components/zip-download/jsonGenerator.ts
@@ -177,9 +177,9 @@ export const generateExportJson = async (
           updated_at: currentDate,
           molecule_id: linkedMoleculeId,
           molecule_name_id: linkedMoleculeId
-            ? (Object.entries(uidToMoleculeName).find(
+            ? Object.entries(uidToMoleculeName).find(
                 ([, mn]) => mn.molecule_id === linkedMoleculeId,
-              )?.[0] ?? null)
+              )?.[0] ?? null
             : null,
           molfile: moleculeMolfile,
           decoupled: moleculeMolfile || moleculeCanoSmiles ? false : true,

--- a/src/app/components/zip-download/jsonGenerator.ts
+++ b/src/app/components/zip-download/jsonGenerator.ts
@@ -150,6 +150,7 @@ export const generateExportJson = async (
 
     // Get molecule molfile to copy to sample
     const moleculeMolfile = moleculeFolder?.metadata?.molfile || null
+    const moleculeCanoSmiles = moleculeFolder?.metadata?.cano_smiles || null
 
     // Format temperature fields for export (append ..Infinity to single numbers)
     const formattedMetadata = { ...folder.metadata }
@@ -175,9 +176,13 @@ export const generateExportJson = async (
           created_at: currentDate,
           updated_at: currentDate,
           molecule_id: linkedMoleculeId,
-          molecule_name_id: null, // Always null for export - prevents referencing non-existent MoleculeName UUIDs
+          molecule_name_id: linkedMoleculeId
+            ? (Object.entries(uidToMoleculeName).find(
+                ([, mn]) => mn.molecule_id === linkedMoleculeId,
+              )?.[0] ?? null)
+            : null,
           molfile: moleculeMolfile,
-          decoupled: moleculeMolfile ? false : true,
+          decoupled: moleculeMolfile || moleculeCanoSmiles ? false : true,
           name: moleculeMolfile
             ? null
             : formattedMetadata.name || folder.name || 'decoupled sample',

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,3 +100,8 @@
 .quill-wrapper .ql-toolbar {
   border-radius: 0.25rem 0.25rem 0 0;
 }
+
+/* Keep selected value visible (not greyed) when TreeSelect dropdown is open */
+.ant-select-open .ant-select-selection-item {
+  color: rgba(0, 0, 0, 0.88) !important;
+}

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -71,6 +71,7 @@ export type ExtendedFolder = {
   metadata?: Metadata
   name: string
   parentUid: string
+  position?: number
   reactionSchemeType: ReactionSchemeType
   treeId: string
   uid: string
@@ -86,6 +87,11 @@ export class FilesDBCreator extends Dexie {
       files: '++id, fullPath, name, uid, extension, parentUid, treeId',
       folders:
         '++id, fullPath, name, uid, parentUid, treeId, dtype, reactionSchemeType',
+    })
+    this.version(2).stores({
+      files: '++id, fullPath, name, uid, extension, parentUid, treeId',
+      folders:
+        '++id, fullPath, name, uid, parentUid, treeId, dtype, reactionSchemeType, position',
     })
   }
 }

--- a/src/helper/canDropAt.ts
+++ b/src/helper/canDropAt.ts
@@ -6,29 +6,6 @@ const canDropAt = (
   target: DraggingPosition,
   treeData: Record<string, FileNode>,
 ) => {
-  console.log('=== DRAG & DROP ATTEMPT ===')
-
-  console.log(
-    'Items being dragged:',
-    items.map((item) => ({
-      index: item.index,
-      data: item.data,
-      isFolder: item.isFolder,
-      metadata: treeData[item.index]?.metadata,
-      fullNodeData: treeData[item.index],
-    })),
-  )
-  console.log('Target:', {
-    targetType: target.targetType,
-    ...(target.targetType === 'item' && {
-      targetItem: (target as any).targetItem,
-    }),
-    ...(target.targetType === 'between-items' && {
-      parentItem: (target as any).parentItem,
-    }),
-    treeId: target.treeId,
-  })
-
   const isDroppable = (parent: FileNode) =>
     !parent.children.some(
       (child) => treeData[child].data === treeData[items[0].index].data,
@@ -45,17 +22,16 @@ const canDropAt = (
     }
   }
 
-  // Basic duplicate name check
+  // Basic duplicate name check — skip only if an analysis is reordering within its own analyses folder
   const targetNode = getTargetNode()
-  console.log('Target node:', {
-    targetNode,
-    data: targetNode?.data,
-    metadata: targetNode?.metadata,
-    isFolder: targetNode?.isFolder,
-  })
+  const sourceNodeForReorder = treeData[items[0].index]
+  const isReorderingWithinSameParent =
+    target.targetType === 'between-items' &&
+    sourceNodeForReorder?.dtype === 'analysis' &&
+    targetNode?.dtype === 'analyses' &&
+    targetNode?.children?.includes(String(items[0].index))
 
-  if (targetNode && !isDroppable(targetNode)) {
-    console.log('❌ BLOCKED: Duplicate name in same parent')
+  if (targetNode && !isReorderingWithinSameParent && !isDroppable(targetNode)) {
     return false
   }
 
@@ -68,14 +44,6 @@ const canDropAt = (
     const hasFileExtension = /\.[a-zA-Z0-9]+$/.test(sourceName)
     const isActuallyAFolder = !hasFileExtension
 
-    console.log('🔍 ExportFiles check:', {
-      targetTreeId: target.treeId,
-      sourceIndex: items[0].index,
-      sourceName,
-      hasFileExtension,
-      isActuallyAFolder,
-      originalIsFolder: sourceNode?.isFolder || items[0].isFolder,
-    })
 
     if (isActuallyAFolder) {
       // Allow samples to be dropped into reactions within ExportFiles area
@@ -97,25 +65,14 @@ const canDropAt = (
       const isTargetDataset = targetNode?.dtype === 'dataset'
 
       if (isSample && isTargetReaction) {
-        console.log(
-          '✅ ALLOWED: Sample can be dropped into reaction in ExportFiles area',
-        )
         // Continue with other validation rules
       } else if (isDataset && isTargetAnalysis) {
-        console.log(
-          '✅ ALLOWED: Dataset can be dropped into analysis in ExportFiles area',
-        )
-        // Continue with other validation rules
+        // allowed
       } else if (isAnalysis && isTargetAnalyses) {
-        console.log(
-          '✅ ALLOWED: Analysis can be dropped into analyses folder in ExportFiles area',
-        )
-        // Continue with other validation rules
+        // allowed
       } else if (isSimpleFolder && isTargetDataset) {
-        console.log('✅ ALLOWED: Simple folder can be dropped into dataset')
-        // Continue with other validation rules
+        // allowed
       } else {
-        console.log('❌ BLOCKED: Only files can be dropped in ExportFiles area')
         return false
       }
     }
@@ -130,28 +87,11 @@ const canDropAt = (
       const targetName = targetNode?.data || ''
       const isTargetDataset = targetNode?.dtype === 'dataset'
 
-      console.log('🔍 Dataset container check:', {
-        targetName,
-        isTargetDataset,
-        sourceName,
-      })
-
       if (
         !isTargetDataset &&
         targetNode?.dtype &&
         targetNode?.dtype !== 'folder'
       ) {
-        console.log(
-          '❌ BLOCKED: Files can only be dropped in dataset containers',
-          {
-            targetName,
-            targetType: target.targetType,
-            targetItem:
-              target.targetType === 'item' ? target.targetItem : 'N/A',
-            parentItem:
-              target.targetType === 'between-items' ? target.parentItem : 'N/A',
-          },
-        )
         return false
       }
     }
@@ -173,20 +113,7 @@ const canDropAt = (
         sourceNode?.dtype === 'reaction' ||
         sourceNode?.dtype === 'dataset'
 
-      console.log('🔍 UploadFiles check:', {
-        targetTreeId: target.treeId,
-        sourceIndex: items[0].index,
-        sourceName,
-        sourceDtype: sourceNode?.dtype,
-        isActuallyAFolder,
-        isRestrictedFolder,
-        originalIsFolder: sourceNode?.isFolder || items[0].isFolder,
-      })
-
       if (isRestrictedFolder) {
-        console.log(
-          '❌ BLOCKED: Cannot drop analyses, sample, reaction, or dataset folders into upload area',
-        )
         return false
       }
     }
@@ -195,10 +122,6 @@ const canDropAt = (
   // Business logic: Use dtype for reliable type detection
   const sourceNode = treeData[items[0].index]
   if (sourceNode && targetNode) {
-    const sourceName = items[0].data || sourceNode.data
-    const targetName = targetNode.data
-
-    // Detect item types by dtype (much more reliable than name-based detection)
     const isSourceReaction = sourceNode.dtype === 'reaction'
     const isSourceAnalysis = sourceNode.dtype === 'analysis'
     const isSourceSample = sourceNode.dtype === 'sample'
@@ -207,60 +130,25 @@ const canDropAt = (
     const isTargetSample = targetNode.dtype === 'sample'
     const isTargetAnalyses = targetNode.dtype === 'analyses'
 
-    console.log('🔍 Business logic check:', {
-      sourceName,
-      targetName,
-      sourceDtype: sourceNode.dtype,
-      targetDtype: targetNode.dtype,
-      isSourceReaction,
-      isSourceAnalysis,
-      isSourceSample,
-      isSourceDataset,
-      isTargetReaction,
-      isTargetSample,
-      isTargetAnalyses,
-    })
-
     // Rule 1: Reaction cannot be dropped into Sample
-    if (isSourceReaction && isTargetSample) {
-      console.log('❌ BLOCKED: Cannot drop reaction into sample')
-      return false
-    }
+    if (isSourceReaction && isTargetSample) return false
 
     // Rule 2: Reaction cannot be dropped into another Reaction
-    if (isSourceReaction && isTargetReaction) {
-      console.log('❌ BLOCKED: Cannot drop reaction into another reaction')
-      return false
-    }
+    if (isSourceReaction && isTargetReaction) return false
 
     // Rule 3: Analysis can only be dropped into analyses folder
-    if (isSourceAnalysis && !isTargetAnalyses) {
-      console.log(
-        '❌ BLOCKED: Analysis can only be dropped into analyses folder',
-      )
-      return false
-    }
+    if (isSourceAnalysis && !isTargetAnalyses) return false
 
     // Rule 4: Sample cannot be dropped into another Sample
-    if (isSourceSample && isTargetSample) {
-      console.log('❌ BLOCKED: Cannot drop sample into another sample')
-      return false
-    }
+    if (isSourceSample && isTargetSample) return false
 
     // Rule 5: Dataset can only be dropped into analysis items (not reactions, samples, or analyses folders)
     if (isSourceDataset) {
       const isTargetAnalysis = targetNode.dtype === 'analysis'
-
-      if (!isTargetAnalysis) {
-        console.log(
-          '❌ BLOCKED: Dataset can only be dropped into analysis items',
-        )
-        return false
-      }
+      if (!isTargetAnalysis) return false
     }
   }
 
-  console.log('✅ ALLOWED: Drop permitted')
   return true
 }
 

--- a/src/helper/canDropAt.ts
+++ b/src/helper/canDropAt.ts
@@ -44,7 +44,6 @@ const canDropAt = (
     const hasFileExtension = /\.[a-zA-Z0-9]+$/.test(sourceName)
     const isActuallyAFolder = !hasFileExtension
 
-
     if (isActuallyAFolder) {
       // Allow samples to be dropped into reactions within ExportFiles area
       const isSample = sourceNode?.dtype === 'sample'
@@ -84,7 +83,6 @@ const canDropAt = (
       typeof window !== 'undefined' &&
       !(window as any).Cypress
     ) {
-      const targetName = targetNode?.data || ''
       const isTargetDataset = targetNode?.dtype === 'dataset'
 
       if (

--- a/src/helper/handleFileMove.ts
+++ b/src/helper/handleFileMove.ts
@@ -144,60 +144,65 @@ const handleFileMove = async (
 
   if (updatesBatch.length === 0) return
 
-  await filesDB.transaction(
-    'rw',
-    filesDB.files,
-    filesDB.folders,
-    async () => {
-      await Promise.all(
-        updatesBatch.map(async (update) => {
-          const table = update.isFolder ? filesDB.folders : filesDB.files
-          const item = await table.get({ uid: update.uid })
-          if (!item)
-            return console.error('Item not found in database:', update.uid)
-          item.fullPath = update.fullPath
-          item.parentUid = update.parentUid
-          item.treeId = update.treeId
-          if (item.metadata) {
-            item.metadata.parent_id = update.parentUid
-            item.metadata.ancestry = update.parentUid
-            item.metadata.updated_at = new Date().toISOString()
-          }
-          await table.put(item as ExtendedFile & ExtendedFolder)
-        }),
-      )
+  await filesDB.transaction('rw', filesDB.files, filesDB.folders, async () => {
+    await Promise.all(
+      updatesBatch.map(async (update) => {
+        const table = update.isFolder ? filesDB.folders : filesDB.files
+        const item = await table.get({ uid: update.uid })
+        if (!item)
+          return console.error('Item not found in database:', update.uid)
+        item.fullPath = update.fullPath
+        item.parentUid = update.parentUid
+        item.treeId = update.treeId
+        if (item.metadata) {
+          item.metadata.parent_id = update.parentUid
+          item.metadata.ancestry = update.parentUid
+          item.metadata.updated_at = new Date().toISOString()
+        }
+        await table.put(item as ExtendedFile & ExtendedFolder)
+      }),
+    )
 
-      // Update positions when an analysis is reordered within its analyses parent
-      if (target.targetType === 'between-items' && items.length === 1) {
-        const sourceNode = tree[items[0].index]
-        const parentNode = tree[target.parentItem]
-        if (sourceNode?.dtype === 'analysis' && parentNode?.dtype === 'analyses') {
-          const siblings = await filesDB.folders
-            .where('parentUid')
-            .equals(String(parentNode.uid))
-            .and((f) => f.dtype === 'analysis')
-            .toArray()
-          const treeChildren = parentNode.children ?? []
-          siblings.sort((a, b) =>
+    // Update positions when an analysis is reordered within its analyses parent
+    if (target.targetType === 'between-items' && items.length === 1) {
+      const sourceNode = tree[items[0].index]
+      const parentNode = tree[target.parentItem]
+      if (
+        sourceNode?.dtype === 'analysis' &&
+        parentNode?.dtype === 'analyses'
+      ) {
+        const siblings = await filesDB.folders
+          .where('parentUid')
+          .equals(String(parentNode.uid))
+          .and((f) => f.dtype === 'analysis')
+          .toArray()
+        const treeChildren = parentNode.children ?? []
+        siblings.sort(
+          (a, b) =>
             (a.position ?? treeChildren.indexOf(a.fullPath)) -
             (b.position ?? treeChildren.indexOf(b.fullPath)),
+        )
+        const draggedUid = String(sourceNode.uid)
+        const dragged = siblings.find((s) => s.uid === draggedUid)
+        const withoutDragged = siblings.filter((s) => s.uid !== draggedUid)
+        if (dragged) {
+          const originalIndex = treeChildren.indexOf(dragged.fullPath)
+          const insertAt = Math.min(
+            originalIndex < target.childIndex
+              ? target.childIndex - 1
+              : target.childIndex,
+            withoutDragged.length,
           )
-          const draggedUid = String(sourceNode.uid)
-          const dragged = siblings.find((s) => s.uid === draggedUid)
-          const withoutDragged = siblings.filter((s) => s.uid !== draggedUid)
-          if (dragged) {
-            const originalIndex = treeChildren.indexOf(dragged.fullPath)
-            const insertAt = Math.min(
-              originalIndex < target.childIndex ? target.childIndex - 1 : target.childIndex,
-              withoutDragged.length,
-            )
-            withoutDragged.splice(insertAt, 0, dragged)
-          }
-          await Promise.all(withoutDragged.map((f, idx) => filesDB.folders.update(f.id!, { position: idx })))
+          withoutDragged.splice(insertAt, 0, dragged)
         }
+        await Promise.all(
+          withoutDragged.map((f, idx) =>
+            filesDB.folders.update(f.id!, { position: idx }),
+          ),
+        )
       }
-    },
-  )
+    }
+  })
 
   // Show success notification after successful drop
   dragNotifications.showSuccess(

--- a/src/helper/handleFileMove.ts
+++ b/src/helper/handleFileMove.ts
@@ -148,7 +148,7 @@ const handleFileMove = async (
     'rw',
     filesDB.files,
     filesDB.folders,
-    async () =>
+    async () => {
       await Promise.all(
         updatesBatch.map(async (update) => {
           const table = update.isFolder ? filesDB.folders : filesDB.files
@@ -165,7 +165,38 @@ const handleFileMove = async (
           }
           await table.put(item as ExtendedFile & ExtendedFolder)
         }),
-      ),
+      )
+
+      // Update positions when an analysis is reordered within its analyses parent
+      if (target.targetType === 'between-items' && items.length === 1) {
+        const sourceNode = tree[items[0].index]
+        const parentNode = tree[target.parentItem]
+        if (sourceNode?.dtype === 'analysis' && parentNode?.dtype === 'analyses') {
+          const siblings = await filesDB.folders
+            .where('parentUid')
+            .equals(String(parentNode.uid))
+            .and((f) => f.dtype === 'analysis')
+            .toArray()
+          const treeChildren = parentNode.children ?? []
+          siblings.sort((a, b) =>
+            (a.position ?? treeChildren.indexOf(a.fullPath)) -
+            (b.position ?? treeChildren.indexOf(b.fullPath)),
+          )
+          const draggedUid = String(sourceNode.uid)
+          const dragged = siblings.find((s) => s.uid === draggedUid)
+          const withoutDragged = siblings.filter((s) => s.uid !== draggedUid)
+          if (dragged) {
+            const originalIndex = treeChildren.indexOf(dragged.fullPath)
+            const insertAt = Math.min(
+              originalIndex < target.childIndex ? target.childIndex - 1 : target.childIndex,
+              withoutDragged.length,
+            )
+            withoutDragged.splice(insertAt, 0, dragged)
+          }
+          await Promise.all(withoutDragged.map((f, idx) => filesDB.folders.update(f.id!, { position: idx })))
+        }
+      }
+    },
   )
 
   // Show success notification after successful drop

--- a/src/helper/importFromZip.ts
+++ b/src/helper/importFromZip.ts
@@ -676,7 +676,7 @@ export const importFromJsonOrZip = async (file: File) => {
       }
     } else if (container.container_type === CONTAINER_TYPE_ANALYSES) {
       dtype = 'analyses'
-      folderName = ANALYSES_FOLDER_NAME
+      folderName = container.name || ANALYSES_FOLDER_NAME
       // Use template for field definitions, then merge container metadata
       metadata = {
         ...containerTemplate,
@@ -804,7 +804,6 @@ export const importFromJsonOrZip = async (file: File) => {
       if (sample?.molfile || sample?.molecule_id) {
         // Create molecule folder
         const moleculeUid = v4()
-        const moleculeFolderPath = `${folderPath}/${DEFAULT_MOLECULE_NAME}`
 
         // Start with template to ensure all fields exist
         let moleculeMetadata: Record<string, unknown> = {
@@ -829,12 +828,31 @@ export const importFromJsonOrZip = async (file: File) => {
           }
         }
 
+        // Derive molecule folder name from MoleculeName, metadata, or default
+        let moleculeName = DEFAULT_MOLECULE_NAME
+        if (exportData.MoleculeName && sample.molecule_id) {
+          const moleculeNameEntry = Object.values(
+            exportData.MoleculeName,
+          ).find((mn) => mn.molecule_id === sample.molecule_id)
+          if (moleculeNameEntry?.name) {
+            moleculeName = moleculeNameEntry.name
+          }
+        }
+        if (
+          moleculeName === DEFAULT_MOLECULE_NAME &&
+          moleculeMetadata.iupac_name
+        ) {
+          moleculeName = String(moleculeMetadata.iupac_name)
+        }
+
+        const moleculeFolderPath = `${folderPath}/${moleculeName}`
+
         await filesDB.folders.add({
           dtype: 'molecule',
           fullPath: moleculeFolderPath,
           isFolder: true,
           metadata: moleculeMetadata as Metadata,
-          name: DEFAULT_MOLECULE_NAME,
+          name: moleculeName,
           parentUid: containerUid,
           reactionSchemeType: 'none',
           treeId: TARGET_TREE_ROOT,
@@ -845,7 +863,7 @@ export const importFromJsonOrZip = async (file: File) => {
         addFolderToTree(
           tree,
           moleculeFolderPath,
-          DEFAULT_MOLECULE_NAME,
+          moleculeName,
           moleculeUid,
         )
 

--- a/src/helper/importFromZip.ts
+++ b/src/helper/importFromZip.ts
@@ -831,9 +831,9 @@ export const importFromJsonOrZip = async (file: File) => {
         // Derive molecule folder name from MoleculeName, metadata, or default
         let moleculeName = DEFAULT_MOLECULE_NAME
         if (exportData.MoleculeName && sample.molecule_id) {
-          const moleculeNameEntry = Object.values(
-            exportData.MoleculeName,
-          ).find((mn) => mn.molecule_id === sample.molecule_id)
+          const moleculeNameEntry = Object.values(exportData.MoleculeName).find(
+            (mn) => mn.molecule_id === sample.molecule_id,
+          )
           if (moleculeNameEntry?.name) {
             moleculeName = moleculeNameEntry.name
           }
@@ -860,12 +860,7 @@ export const importFromJsonOrZip = async (file: File) => {
         })
 
         // Add molecule to tree
-        addFolderToTree(
-          tree,
-          moleculeFolderPath,
-          moleculeName,
-          moleculeUid,
-        )
+        addFolderToTree(tree, moleculeFolderPath, moleculeName, moleculeUid)
 
         sampleUidToMoleculeUid[containerUid] = moleculeUid
       }

--- a/src/helper/retrieveTree.ts
+++ b/src/helper/retrieveTree.ts
@@ -42,6 +42,7 @@ const convertToFileTree = (
         // Sort children: if parent is a reaction, sort samples by reactionSchemeType
         const childrenKeys = Object.keys(currentFolder.children)
         const isReaction = currentFolder.folderObj.dtype === 'reaction'
+        const isAnalyses = currentFolder.folderObj.dtype === 'analyses'
 
         const getSortOrder = (child: any): number => {
           if ('extension' in child) return REACTION_SCHEME_ORDER.none
@@ -58,6 +59,20 @@ const convertToFileTree = (
                 getSortOrder(currentFolder.children[a]) -
                 getSortOrder(currentFolder.children[b]),
             )
+          : isAnalyses
+          ? [...childrenKeys].sort((a, b) => {
+              const childA = currentFolder.children[a]
+              const childB = currentFolder.children[b]
+              const posA =
+                'folderObj' in childA
+                  ? (childA.folderObj.position ?? Infinity)
+                  : Infinity
+              const posB =
+                'folderObj' in childB
+                  ? (childB.folderObj.position ?? Infinity)
+                  : Infinity
+              return posA - posB
+            })
           : childrenKeys
 
         const folderNode = {

--- a/src/helper/retrieveTree.ts
+++ b/src/helper/retrieveTree.ts
@@ -65,11 +65,11 @@ const convertToFileTree = (
               const childB = currentFolder.children[b]
               const posA =
                 'folderObj' in childA
-                  ? (childA.folderObj.position ?? Infinity)
+                  ? childA.folderObj.position ?? Infinity
                   : Infinity
               const posB =
                 'folderObj' in childB
-                  ? (childB.folderObj.position ?? Infinity)
+                  ? childB.folderObj.position ?? Infinity
                   : Infinity
               return posA - posB
             })

--- a/src/helper/utils.ts
+++ b/src/helper/utils.ts
@@ -182,7 +182,6 @@ const hiddenKeys = Object.freeze([
   'molfile_version',
   'is_partial',
   'deleted_at',
-  'iupac_name',
   'molecule_svg_file',
   'mol3k',
   'mol2k',
@@ -196,10 +195,10 @@ const hiddenKeys = Object.freeze([
 // Add any schema type and keys you want to hide for that schema
 const schemaSpecificHiddenKeys: Record<string, readonly string[]> =
   Object.freeze({
-    sample: ['molfile', 'inventory_sample'], // Hide molfile for samples
+    sample: ['molfile', 'inventory_sample', 'iupac_name'], // Hide molfile and iupac_name for samples
     root: ['molfile'], // Hide molfile for root containers (imported samples with container_type: 'root')
-    molecule: ['melting_point', 'boiling_point', 'name'], // Hide these molecule fields (in addition to global hiddenKeys)
-    reaction: [], // Show all reaction-specific keys
+    molecule: ['melting_point', 'boiling_point', 'name'], // Hide these molecule fields (name is injected from folder.name instead)
+    reaction: ['iupac_name'], // Hide iupac_name for reactions
     analyses: ['description', 'container_type'], // Show all analysis-specific keys
     analysis: [], // Show all analysis-specific keys
     dataset: [], // Show all dataset-specific keys

--- a/src/hooks/usePopupPosition.ts
+++ b/src/hooks/usePopupPosition.ts
@@ -1,0 +1,21 @@
+import { RefObject, useLayoutEffect, useState } from 'react'
+
+export function usePopupPosition(
+  ref: RefObject<HTMLElement | null>,
+  x: number,
+  y: number,
+) {
+  const [pos, setPos] = useState({ left: x, top: y })
+
+  useLayoutEffect(() => {
+    if (!ref.current) return
+    const rect = ref.current.getBoundingClientRect()
+    const pad = 8
+    setPos({
+      left: Math.min(x, window.innerWidth - rect.width - pad),
+      top: Math.min(y, window.innerHeight - rect.height - pad),
+    })
+  }, [ref, x, y])
+
+  return pos
+}

--- a/src/hooks/useRename.ts
+++ b/src/hooks/useRename.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+
+import { ExtendedFile, ExtendedFolder } from '@/database/db'
+import { FileNode } from '@/helper/types'
+
+import renameFile from '@/app/components/context-menu/renameFile'
+import renameFolder from '@/app/components/context-menu/renameFolder'
+
+export function useRename(
+  item: ExtendedFile | ExtendedFolder,
+  tree: Record<string, FileNode>,
+  onDone: () => void,
+) {
+  const [newName, setNewName] = useState(item.name)
+  const [isValid, setIsValid] = useState(false)
+
+  const validate = (userInput: string) => {
+    setNewName(userInput)
+    const parentPath =
+      item.fullPath.split('/').slice(0, -1).join('/') || item.treeId
+
+    const validInput = userInput.trim().length > 0 && !userInput.includes('/')
+
+    const newPath =
+      parentPath === item.treeId ? userInput : parentPath + '/' + userInput
+
+    const parentNode = tree[parentPath]
+    const nameAvailable = parentNode
+      ? !parentNode.children.includes(newPath)
+      : true
+
+    setIsValid(validInput && nameAvailable)
+  }
+
+  const reset = () => {
+    setNewName(item.name)
+    setIsValid(false)
+  }
+
+  const executeRename = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!isValid) return
+
+    const treeNode = tree[item.fullPath]
+    if (treeNode) treeNode.data = newName
+
+    if (!item.isFolder) renameFile(item as ExtendedFile, newName)
+    else renameFolder(item as ExtendedFolder, tree, newName)
+
+    onDone()
+  }
+
+  return { newName, isValid, validate, reset, executeRename }
+}


### PR DESCRIPTION
What this PR does:                                                                                 
                                                                                                       
  1. Inline Analysis Management
  - "Add analysis" button directly in the tree UI (no context menu needed)                             
  - Rename is blocked on analyses nodes to prevent accidental changes                                  
                                                                     
  2. Drag-and-Drop Reordering                                                                          
  - Analyses inside folders can be reordered by dragging                                               
  - New order persists to the database                  
  - Analyses get assigned a position on creation                                                       
                  
  3. Ontology Tree — "Recently Selected"                                                               
  - Adds a recently selected section to the ontology tree picker
                                                                                                       
  4. Auto-expand + Notifications
  - Tree auto-expands when a new analysis/sample is added                                              
  - Shows a notification on item creation                                                              
   
  5. Inspector Sidebar                                                                                 
  - Editable molecule name and IUPAC name fields
  - Clears inspector when an item is deleted    
  - Injects folder name for molecule-type items

  6. Shared Components                                                                                 
  - New RenameForm.tsx and DeleteConfirm.tsx reusable components
  - Context menu refactored to use these shared components                                             
                  
  7. Data Export Fix                                                                                   
  - Corrected molecule_name_id and decoupled flag in sample exports
                                                                                                       
  8. Infrastructure
  - Dockerfile: Node 18 → 20-alpine + added libc6-compat for Tailwind CSS native bindings 
  
  
  Test Instance: https://az-smartadd.deploy.chemdev.scc.kit.edu/
  
  